### PR TITLE
Upgrade .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # configuration file for continuous integration testing using travis-ci.org
 
 dist:
- - xenial
+ - jammy
  
 language: 
  - python


### PR DESCRIPTION
The Travis CI builds for the latest two commits appear to be failing due to using python3.6 which doesn't allow to install the new numpy and scipy versions. 

I upgraded the CI config file to use Ubuntu 2022.04, which provides python 3.10. This should work and works on my Ubuntu 2022.04 machine, but I didn't run it on Travis CI.